### PR TITLE
switch to new barrier guru endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ const avAuth = () => {
 
 			barrierGuru.getBarrierData(clientIp)
 				.then(response => {
+					if(!response.displayName) {
+						throw new Error('No corporate data for barrier');
+					}
 					res.render(path.join(__dirname, 'views/barrier'), {
 						barrierModel: _.extend({}, barrierModel,{
 							title: 'Join your group subscription to access FT.com',

--- a/services/barrier-guru.js
+++ b/services/barrier-guru.js
@@ -6,7 +6,7 @@ const rp = require('request-promise');
 
 const getBarrierData = (ip) => {
 	const options = {
-		uri: 'https://' + barrierGuruUrl + '/corporate',
+		uri: 'https://' + barrierGuruUrl + '/barrier',
 		headers: {
 			'x-api-key': barrierGuruKey,
 			'client-ip': ip


### PR DESCRIPTION
`next-barrier-guru` has a single endpoint now (`/barrier`) that serves barriers for both b2b and b2c users. We will be deprecating `/corporate`. These changes ensure that only b2b responses are considered for the Alphaville barrier.